### PR TITLE
Allowing predefined prefix list in the "author" tag.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,8 +3,30 @@ layout: default
 ---
 <h1>{{ page.title }}</h1>
 <p>
+  {% comment %}
+    You could use "author" tag with a predefined list of resources: github, fb, twitter and vk
+    The record "github:username" will be converted into "https://github.com/username"
+
+    The same applies to other allowed resources in the list. All other possible prefixes will be
+    ignored and the link will be generated as "https://t.me/text".
+  {% endcomment %}
+
   {{ page.date | date_to_string }}
+  {% if page.author %}
+    {% assign sites = "github,fb,twitter,vk" | split: ',' %}
+    {% for site in sites %}
+        {% assign current_site = page.author | split: ':' | first %}
+        {% if current_site == site %}
+            {% assign matched = true %}
+            {% break %}
+        {% endif %}
+    {% endfor %}
+    {% if matched %}
+    - <a target="_blank" href="https://{{ current_site }}.com/{{ page.author | split: ':' | last }}">{{ page.author | split: ':' | last }}</a>
+    {% else %}
     - <a target="_blank" href="https://t.me/{{ page.author }}">{{ page.author }}</a>
+    {% endif %}
+  {% endif %}
 </p>
 
 {{ content }}

--- a/_posts/2019-06-14-bogon-asns.md
+++ b/_posts/2019-06-14-bogon-asns.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Catching bogon ASNs on the Internet"
 tags: python ripe bgp mrt
-author: freefd
+author: github:freefd
 ---
 
 Today we will try to find bogon ASNs without any network equipment using only RIPE RIS wild Internet routing information and our modest coding skills in Python 3. Probably, you may want to use this PoC to monitor your own network.

--- a/_posts/2019-11-03-old-fashioned-way-about-data-science.md
+++ b/_posts/2019-11-03-old-fashioned-way-about-data-science.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Old-fashioned Way About Data Science"
 tags: linux cli shell gnuplot
-author: "freefd"
+author: "github:freefd"
 ---
 
 The usual Pythonic way to get a data series is sometimes not the fastest. In some cases, it's enough to have only 3-6 Linux CLI tools to get a necessary data from Web and parse it in a proper way. Let's look at such an approach on how to count the number of released RFC's per year and draw the graph in a terminal.


### PR DESCRIPTION
Allow to use predefined resource prefixes with the "author" tag in posts:
  github, fb, twitter and vk
For example, record "github:username" will be converted into "https://github.com/username".
The same applies to other allowed resources in the list. All other possible prefixes will be ignored and the link will be generated as "https://t.me/text".
